### PR TITLE
Include recent Python versions in default tox axis

### DIFF
--- a/src/main/java/jenkins/plugins/shiningpanda/matrix/ToxAxis.java
+++ b/src/main/java/jenkins/plugins/shiningpanda/matrix/ToxAxis.java
@@ -125,7 +125,7 @@ public class ToxAxis extends Axis {
 	 * Default TOX environments
 	 */
 	public static final List<String> DEFAULTS = Collections.unmodifiableList(Arrays.asList(
-		new String[] { "py24", "py25", "py26", "py27", "py30", "py31", "py32", "py33", "jython", "pypy" }));
+		new String[] { "py24", "py25", "py26", "py27", "py30", "py31", "py32", "py33", "py34", "py35", "jython", "pypy" }));
 
 	/*
 	 * (non-Javadoc)


### PR DESCRIPTION
Add "py34" and "py35" to the default list of tox environments.