### PR TITLE
don't allow pip prereleases to be installed

### DIFF
--- a/src/main/resources/jenkins/plugins/shiningpanda/workspace/virtualenv.py
+++ b/src/main/resources/jenkins/plugins/shiningpanda/workspace/virtualenv.py
@@ -889,7 +889,6 @@ def install_wheel(project_names, py_executable, search_dirs=None,
         "PIP_FIND_LINKS": findlinks,
         "PIP_USE_WHEEL": "1",
         "PIP_ONLY_BINARY": ":all:",
-        "PIP_PRE": "1",
         "PIP_USER": "0",
     }
 


### PR DESCRIPTION
Currently, the ShiningPanda plugin will install beta versions of pip because this environment variable is set.

In the upstream virtualenv library, this environment variable was removed as part of a huge commit more than 2 years ago: https://github.com/pypa/virtualenv/commit/417cb0318a962286f4de5d3defde2923c71b29f7