### PR TITLE
Related to pip 10, call pip as module instead

### DIFF
--- a/src/main/java/jenkins/plugins/shiningpanda/interpreters/Virtualenv.java
+++ b/src/main/java/jenkins/plugins/shiningpanda/interpreters/Virtualenv.java
@@ -303,9 +303,9 @@ public class Virtualenv extends Python {
 	// Add path to PYTHON executable
 	args.add(getExecutable().getRemote());
 	// Call PIP via command line
-	args.add("-c");
+	args.add("-m");
 	// Command line script to call PIP
-	args.add("import pip; pip.main();");
+	args.add("pip");
 	// Require an installation
 	args.add("install");
 	// Get the folder where packages can be found (PIP, ...)


### PR DESCRIPTION
`import main` no longer works in pip 10, and was apparently never encouraged. Calling pip as a module would be the proper way to do this, and should work regardless of python implementation.