### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/src/main/resources/jenkins/plugins/shiningpanda/actions/coverage/CoverageAction/entries.jelly
+++ b/src/main/resources/jenkins/plugins/shiningpanda/actions/coverage/CoverageAction/entries.jelly
@@ -23,7 +23,7 @@ If not, see <https://raw.github.com/jenkinsci/shiningpanda-plugin/master/LICENSE
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="Coverage report » ${title}">
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/graph.png" alt="" height="48" width="48"/> ${title}</h1>
+      <h1>${title}</h1>
       <j:choose>
         <j:when test="${empty(entries)}">
           ${%No HTML reports.}

--- a/src/main/resources/jenkins/plugins/shiningpanda/actions/coverage/CoverageProjectAction/entries.jelly
+++ b/src/main/resources/jenkins/plugins/shiningpanda/actions/coverage/CoverageProjectAction/entries.jelly
@@ -23,7 +23,7 @@ If not, see <https://raw.github.com/jenkinsci/shiningpanda-plugin/master/LICENSE
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
   <l:layout title="Coverage report » ${title}">
     <l:main-panel>
-      <h1><img src="${imagesURL}/48x48/graph.png" alt="" height="48" width="48"/> ${title}</h1>
+      <h1>${title}</h1>
       <j:choose>
         <j:when test="${empty(entries)}">
           ${%No HTML reports.}


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.
In case of your plugin, I've removed the header icons, because that is what modern Jenkins does now look like.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @omansion 
Thanks in advance!